### PR TITLE
Clarify timeout example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ like the following:
 ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
 defer cancel()
 employeeList, err := client.Hris().Employees().List(
-  context.TODO(),
+  ctx,
   &hris.EmployeesListRequest{
     CreatedBefore: merge.Time(time.Now()),
   },


### PR DESCRIPTION
The created context needs to be passed into the API client for the request to be cancelled correctly. Small update to the README to clarify that